### PR TITLE
Add export_file Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,31 @@ Documentation: <https://crowdin.com/page/api/export>
 crowdin.export_translations
 ```
 
+### Export File
+
+Download translations for a single file from CrowdIn
+
+Parameters:
+
+* :file - The path to the file that should be exported from the project
+* :language - The CrowdIn Language code - see <https://support.crowdin.com/api/language-codes/>
+
+Optional:
+
+* :output - where to save the exported file 
+* :branch - a branch name
+* :format - specify `xliff` to export in XLIFF file format
+* :export_translated_only - Defines whether only translated strings will be exported to the final file. 
+                            Acceptable values are: 1 or 0.
+* :export_approved_only - If set to 1 only approved translations will be exported in resulted file. 
+                          Acceptable values are: 1 or 0.  
+
+Documentation: <https://support.crowdin.com/api/export-file/>
+
+```ruby
+crowdin.export_file({file: 'file_name_on_crowdin.xml', language: :ru, output: './tmp/place_you_want_to_save_locally.xml'})
+```
+
 ### Account Projects
 
 Get Crowdin Project details.

--- a/README.md
+++ b/README.md
@@ -262,17 +262,17 @@ Download translations for a single file from CrowdIn
 
 Parameters:
 
-* :file - The path to the file that should be exported from the project
-* :language - The CrowdIn Language code - see <https://support.crowdin.com/api/language-codes/>
+* `:file` - The path to the file that should be exported from the project
+* `:language` - The CrowdIn Language code - see <https://support.crowdin.com/api/language-codes/>
 
 Optional:
 
-* :output - where to save the exported file 
-* :branch - a branch name
-* :format - specify `xliff` to export in XLIFF file format
-* :export_translated_only - Defines whether only translated strings will be exported to the final file. 
+* `:output` - where to save the exported file 
+* `:branch` - a branch name
+* `:format` - specify `xliff` to export in XLIFF file format
+* `:export_translated_only` - Defines whether only translated strings will be exported to the final file. 
                             Acceptable values are: 1 or 0.
-* :export_approved_only - If set to 1 only approved translations will be exported in resulted file. 
+* `:export_approved_only` - If set to 1 only approved translations will be exported in resulted file. 
                           Acceptable values are: 1 or 0.  
 
 Documentation: <https://support.crowdin.com/api/export-file/>

--- a/lib/crowdin-api/methods.rb
+++ b/lib/crowdin-api/methods.rb
@@ -326,6 +326,8 @@ module Crowdin
       )
     end
 
+    # Download translations for a single file from CrowdIn
+    #
     # == Parameters
     #
     # * :file - The path to the file that should be exported from the project

--- a/lib/crowdin-api/methods.rb
+++ b/lib/crowdin-api/methods.rb
@@ -326,6 +326,36 @@ module Crowdin
       )
     end
 
+    # == Parameters
+    #
+    # * :file - The path to the file that should be exported from the project
+    # * :language - The CrowdIn Language code - see https://support.crowdin.com/api/language-codes/ 
+    #
+    # Optional:
+    #
+    # * :output - where to save the exported file 
+    # * :branch - a branch name
+    # * :format - specify `xliff` to export in XLIFF file format
+    # * :export_translated_only - Defines whether only translated strings will be exported to the final file. 
+    #                             Acceptable values are: 1 or 0.
+    # * :export_approved_only - If set to 1 only approved translations will be exported in resulted file. 
+    #                           Acceptable values are: 1 or 0.  
+    #
+    # == Request
+    #
+    # GET https://api.crowdin.com/api/project/{project-identifier}/export-file?key={project-key}
+    #
+    def export_file(params = {})
+      raise(ArgumentError, "'`:file`' is required") unless params[:file].present?
+      raise(ArgumentError, "'`:language`' is required") unless params[:language].present?
+
+      request(
+        :method => :get,
+        :path   => "/api/project/#{@project_id}/export-file",
+        :output => params.delete(:output),
+        :query  => params
+      )
+    end
 
     # Get supported languages list with Crowdin codes mapped to locale name and standarded codes.
     #


### PR DESCRIPTION
- Wrapped the `export_file` endpoint following existing conventions
- Updated README as was relevant.
- See [https://support.crowdin.com/api/export-file/](https://support.crowdin.com/api/export-file/) for more context.